### PR TITLE
fixed verified artist check

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ app.get(
 				}
 				if (key == "verified" && query[key] == "true") {
 					isVerifiedArtists = true;
-					pipelineInsertion["$match"]["spotify_id"] = { $exists: true };
+					pipelineInsertion["$match"]["$and"] = [{spotify_id: {$exists: true}},{spotify_id: {$ne: null}}];
 				}
 				if (key == "skip") numToSkip = Number(query["skip"]);
 				if (key == "sort"){


### PR DESCRIPTION
Added null check to match stage of aggregation pipeline. 

Previously was only check if spotifyid field existed. Nulls (unverified artists) passed this check. Now must exist and not be null.